### PR TITLE
refactor: watch client api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,11 @@ jobs:
            -coverpkg=./client
            -coverprofile=coverage.out
            -covermode=atomic
+           -v
            ./tests/kv_test.go
            ./tests/auth_test.go
            ./tests/lease_test.go
+           ./tests/watch_test.go
         env:
           GO111MODULE: 'auto'
 

--- a/client/watch.go
+++ b/client/watch.go
@@ -1,27 +1,107 @@
+// Copyright 2023 The xline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (
 	"context"
+	"time"
 
 	xlineapi "github.com/xline-kv/go-xline/api/xline"
+	"github.com/xline-kv/go-xline/xlog"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
+
+type Watch interface {
+	// Watches for events happening or that have happened.
+	Watch(ctx context.Context, key []byte) <-chan *WatchResponse
+}
+
+type WatchResponse xlineapi.WatchResponse
+
+const watchInterval = 5 * time.Millisecond
 
 // Client for Watch operations.
 type watchClient struct {
 	// The watch RPC client, only communicate with one server at a time
 	watchClient xlineapi.WatchClient
+	// The logger for log
+	logger *zap.Logger
 }
 
 // Creates a new maintenance client
 func newWatchClient(conn *grpc.ClientConn) watchClient {
-	return watchClient{watchClient: xlineapi.NewWatchClient(conn)}
+	return watchClient{watchClient: xlineapi.NewWatchClient(conn), logger: xlog.GetLogger()}
 }
 
-func (c watchClient) Watch() (xlineapi.Watch_WatchClient, error) {
-	res, err := c.watchClient.Watch(context.Background())
+// Watches for events happening or that have happened.
+func (c *watchClient) Watch(ctx context.Context, key []byte) (<-chan *WatchResponse, error) {
+	wch := make(chan *WatchResponse)
+	var watchID int64
+
+	wc, err := c.watchClient.Watch(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	return res, nil
+	r := &xlineapi.WatchRequest{
+		RequestUnion: &xlineapi.WatchRequest_CreateRequest{
+			CreateRequest: &xlineapi.WatchCreateRequest{
+				Key: []byte(key),
+			},
+		},
+	}
+	err = wc.Send(r)
+	if err != nil {
+		panic("watch create fail")
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				r := &xlineapi.WatchRequest{
+					RequestUnion: &xlineapi.WatchRequest_CancelRequest{
+						CancelRequest: &xlineapi.WatchCancelRequest{
+							WatchId: watchID,
+						},
+					},
+				}
+				err := wc.Send(r)
+				if err != nil {
+					panic("watch cancel fail")
+				}
+				res, err := wc.Recv()
+				if err != nil {
+					panic("watch cancel fail")
+				}
+				wch <- (*WatchResponse)(res)
+				close(wch)
+				return
+			default:
+				res, err := wc.Recv()
+				if err != nil {
+					c.logger.Error("watch fail", zap.Error(err))
+				}
+				if res.Created {
+					watchID = res.WatchId
+				}
+				wch <- (*WatchResponse)(res)
+			}
+			time.Sleep(watchInterval)
+		}
+	}()
+
+	return wch, nil
 }

--- a/tests/watch_test.go
+++ b/tests/watch_test.go
@@ -1,12 +1,26 @@
+// Copyright 2023 The xline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
 
-	xlineapi "github.com/xline-kv/go-xline/api/xline"
 	"github.com/xline-kv/go-xline/client"
 	"github.com/xline-kv/go-xline/xlog"
 )
@@ -22,44 +36,40 @@ func TestWatch(t *testing.T) {
 	watchClient := client.Watch
 
 	t.Run("watch_should_receive_consistent_events", func(t *testing.T) {
-		watcher, err := watchClient.Watch()
-		assert.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		ch, _ := watchClient.Watch(ctx, []byte("watch01"))
 
-		err = watcher.Send(&xlineapi.WatchRequest{
-			RequestUnion: &xlineapi.WatchRequest_CreateRequest{
-				CreateRequest: &xlineapi.WatchCreateRequest{
-					Key: []byte("watch01"),
-				},
-			},
-		})
-		assert.NoError(t, err)
-		res, err := watcher.Recv()
-		assert.NoError(t, err)
-		id := res.WatchId
+		go func() {
+			kvClient.Put([]byte("watch01"), []byte("01"))
+			kvClient.Put([]byte("watch01"), []byte("02"))
+			kvClient.Put([]byte("watch01"), []byte("03"))
+			cancel()
+		}()
 
-		_, err = kvClient.Put(&xlineapi.PutRequest{Key: []byte("watch01"), Value: []byte("01")})
-		assert.NoError(t, err)
-
-		res, err = watcher.Recv()
-		assert.NoError(t, err)
-		assert.Equal(t, id, res.WatchId)
-		assert.Len(t, res.Events, 1)
-		kv := res.Events[0].Kv
-		assert.Equal(t, "watch01", string(kv.Key))
-		assert.Equal(t, "01", string(kv.Value))
-
-		err = watcher.Send(&xlineapi.WatchRequest{
-			RequestUnion: &xlineapi.WatchRequest_CancelRequest{
-				CancelRequest: &xlineapi.WatchCancelRequest{
-					WatchId: id,
-				},
-			},
-		})
-		assert.NoError(t, err)
-
-		res, err = watcher.Recv()
-		assert.NoError(t, err)
-		assert.Equal(t, id, res.WatchId)
-		assert.True(t, res.Canceled)
+		var watchID int64
+		i := 1
+		for res := range ch {
+			switch i {
+			case 1:
+				watchID = res.WatchId
+				assert.True(t, res.Created)
+			case 2:
+				assert.Equal(t, watchID, res.WatchId)
+				assert.Equal(t, "watch01", string(res.Events[0].Kv.Key))
+				assert.Equal(t, "01", string(res.Events[0].Kv.Value))
+			case 3:
+				assert.Equal(t, watchID, res.WatchId)
+				assert.Equal(t, "watch01", string(res.Events[0].Kv.Key))
+				assert.Equal(t, "02", string(res.Events[0].Kv.Value))
+			case 4:
+				assert.Equal(t, watchID, res.WatchId)
+				assert.Equal(t, "watch01", string(res.Events[0].Kv.Key))
+				assert.Equal(t, "03", string(res.Events[0].Kv.Value))
+			case 5:
+				assert.Equal(t, watchID, res.WatchId)
+				assert.True(t, res.Canceled)
+			}
+			i++
+		}
 	})
 }


### PR DESCRIPTION
Base on #16 

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Refactor watch client api to improve easy of use of the watch clinet feature.

* what changes does this pull request make?
  * refactor watch clinet api & test sample

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
No.
